### PR TITLE
pre-commit: Fix markdownlint tag version: v1.0.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   hooks:
   - id: markdownlint
 -   repo: https://github.com/detailyang/pre-commit-shell.git
-    rev: 1.0.2
+    rev: v1.0.6
     hooks:
     -   id: shell-lint
         args: ["--exclude=SC1090,SC1091,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"]


### PR DESCRIPTION
Note: Latest `v1.0.6` tag diverged from the usual pattern.

Reference:
  - https://github.com/detailyang/pre-commit-shell/tags
